### PR TITLE
Add Profile page and routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import NotFound from './pages/NotFound';
 import Settings from './pages/Settings';
 import About from './pages/About';
+import Profile from './pages/Profile';
 
 function App() {
   const { currentUser } = useAuth();
@@ -26,6 +27,7 @@ function App() {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/about" element={<About />} />
+          <Route path="/profile" element={<Profile />} />
         </Route>
 
         <Route path="*" element={<NotFound />} />

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, Typography, Paper } from '@mui/material';
+
+function Profile() {
+  return (
+    <Box sx={{ py: 2 }}>
+      <Typography variant="h5" sx={{ mb: 4 }}>
+        My Profile
+      </Typography>
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="body1" color="text.secondary">
+          Profile details will appear here.
+        </Typography>
+      </Paper>
+    </Box>
+  );
+}
+
+export default Profile;


### PR DESCRIPTION
## Summary
- add placeholder Profile page component
- include Profile component in routing for protected routes

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685fa9bad1908331ace3bbba328081fe